### PR TITLE
add darvin-webpack boilerplate to website section

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Curated list of boilerplates and templates to enhance productivity.
 - [Jekyll Starter Kit](https://github.com/nirgn975/generator-jekyll-starter-kit) Jekyll Progressive Web App generator boilerplate.
 - [HTML5 UP!](https://html5up.net/) Responsive HTML5 and CSS3 Site Templates.
 - [Gulp front](https://zoxon.github.io/gulp-front/) Frontend boilerplate and framework based on gulp, pug, stylus and babel
+- [Darvin Webpack](https://github.com/unic/darvin-webpack-boilerplate) no-gulp boilerplate with custom settings. Nunjucks or Twig HTML, ES6, Sass, Stylelint, ESLint, Pre-Commit Hooks, Lazy Load Scripts, Browsersync or WDS, CLI for settings and scaffolding and optional Frontend-Preview for shipping.
 
 ##  IDE
 


### PR DESCRIPTION
webpack boilerplate for HTML templating and CMS theming with Nunjucks or Twig. Hot reload with DevServer or Browsersync, easy extendable webpack settings and frontend preview for shipping.