### PR TITLE
Add node-express-mongoose-boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Curated list of boilerplates and templates to enhance productivity.
     - [Node/Backbone Web App Boilerplate](https://github.com/skaapgif/webapp-boilerplate) Boilerplate for web applications with a Node, Express, MongoDB backend and Backbone Marionette, Jade, Require.js frontend.
     - [Nodebootstrap](http://nodebootstrap.io/) Unobtrusive skeleton project for Node/Express.js with pre-configured best-practices.
     - [Vue-Express-Mongo Boilerplate](https://github.com/icebob/vue-express-mongo-boilerplate) - Full stack JS web app boilerplate with Express, Mongo and VueJS.
+    - [Node-Express-Mongoose Boilerplate](https://github.com/hagopj13/node-express-mongoose-boilerplate) - A boilerplate for building production-ready RESTful APIs using Node.js, Express, and Mongoose.
 - [AngularJS](#angular-js)
     - [ng-boilerplate](https://github.com/ngbp/ngbp) An opinionated kickstarter for AngularJS projects.
     - [Yeoman Angular Generator](https://github.com/yeoman/generator-angular)


### PR DESCRIPTION
A boilerplate/starter project for quickly building production-ready RESTful APIs using Node.js, Express, and Mongoose, with many built-in features and best practices.